### PR TITLE
feat: Add a feature to disable map support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,11 @@ thiserror = "1.0"
 uuid = { version = "1.11", optional = true }
 
 [features]
+default = ["map"]
+
+# impl Diffable on `std::collections::BTreeMap` and `std::collections::HashMap`
+map = []
+
 # impl Diffable on `chrono::DateTime`
 chrono = ["dep:chrono"]
 

--- a/difficient-macros/src/lib.rs
+++ b/difficient-macros/src/lib.rs
@@ -1027,7 +1027,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]
@@ -1116,7 +1116,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]
@@ -1191,7 +1191,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]
@@ -1369,7 +1369,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]
@@ -1522,7 +1522,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]
@@ -1557,7 +1557,7 @@ mod tests {
             let f: syn::File = syn::parse2(expect).unwrap();
             prettyplease::unparse(&f)
         };
-        pretty_assertions::assert_eq!(pretty.to_string(), expect.to_string());
+        pretty_assertions::assert_eq!(pretty.clone(), expect.clone());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,12 +515,17 @@ pub mod tests {
 
     // ** Test structs
 
+    #[cfg(feature = "map")]
+    type Child2Map = HashMap<i32, Child2>;
+    #[cfg(not(feature = "map"))]
+    type Child2Map = ();
+
     #[derive(Debug, Clone, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize))]
     pub struct Parent {
         pub c1: Child1,
         pub c2: Vec<Child1>,
-        pub c3: HashMap<i32, Child2>,
+        pub c3: Child2Map,
         pub val: String,
     }
 
@@ -571,7 +576,7 @@ pub mod tests {
     pub struct ParentDiff<'a> {
         pub c1: <Child1 as Diffable<'a>>::Diff,
         pub c2: <Vec<Child1> as Diffable<'a>>::Diff,
-        pub c3: <HashMap<i32, Child2> as Diffable<'a>>::Diff,
+        pub c3: <Child2Map as Diffable<'a>>::Diff,
         pub val: <String as Diffable<'a>>::Diff,
     }
 
@@ -708,6 +713,7 @@ pub mod tests {
 
     #[test]
     fn smoke_test() {
+        #[cfg(feature = "map")]
         fn dummy_child2() -> Child2 {
             Child2 {
                 a: "ayeaye".into(),
@@ -728,6 +734,7 @@ pub mod tests {
                 x: 234,
                 y: "yazoo".into(),
             }],
+            #[cfg(feature = "map")]
             c3: [(
                 321,
                 Child2 {
@@ -738,6 +745,8 @@ pub mod tests {
             )]
             .into_iter()
             .collect(),
+            #[cfg(not(feature = "map"))]
+            c3: (),
             val: "hello".into(),
         };
 
@@ -760,7 +769,10 @@ pub mod tests {
             let expect = DeepDiff::Patched(ParentDiff {
                 c1: DeepDiff::Unchanged,
                 c2: VecDiff::Unchanged,
+                #[cfg(feature = "map")]
                 c3: DeepDiff::Unchanged,
+                #[cfg(not(feature = "map"))]
+                c3: Id::new(),
                 val: AtomicDiff::Replaced(&mello),
             });
             assert_eq!(diff, expect);
@@ -768,6 +780,7 @@ pub mod tests {
             assert_eq!(p3, p4);
         }
 
+        #[cfg(feature = "map")]
         {
             let mut p5 = base.clone();
             let dummy = dummy_child2();
@@ -789,6 +802,7 @@ pub mod tests {
             assert_eq!(err, [ApplyError::MissingKey, ApplyError::UnexpectedKey]);
         }
 
+        #[cfg(feature = "map")]
         {
             let mut map1 = BTreeMap::new();
             let map2 = BTreeMap::from([("hello", "world")]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 #![doc = include_str!("../README.md")]
 
+use std::{marker::PhantomData, ops::Deref};
+
+#[cfg(feature = "map")]
 use std::{
     collections::{BTreeMap, HashMap},
     hash::Hash,
-    marker::PhantomData,
-    ops::Deref,
 };
 
 pub use difficient_macros::Diffable;
@@ -234,6 +235,7 @@ where
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg(feature = "map")]
 /// A generic type which represents the possible change-states of a Key-Value type
 /// (e.g. `HashMap`, `BTreeMap`)
 pub enum KvDiff<'a, T, U> {
@@ -270,6 +272,7 @@ impl_diffable_for_primitives! {
     String
 }
 
+#[cfg(feature = "map")]
 macro_rules! kv_map_impl {
     ($typ: ident, $bounds: ident) => {
         #[allow(
@@ -357,7 +360,10 @@ macro_rules! kv_map_impl {
     };
 }
 
+#[cfg(feature = "map")]
 kv_map_impl!(HashMap, Hash);
+
+#[cfg(feature = "map")]
 kv_map_impl!(BTreeMap, Ord);
 
 impl Diffable<'_> for () {

--- a/src/serde_visit.rs
+++ b/src/serde_visit.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "map")]
 use std::{
     cmp::Ord,
     collections::{BTreeMap, HashMap},
@@ -420,7 +421,10 @@ pub mod tests {
                     y: "y2".into(),
                 },
             ],
+            #[cfg(feature = "map")]
             c3: HashMap::new(),
+            #[cfg(not(feature = "map"))]
+            c3: (),
             val: "val".into(),
         };
 
@@ -452,6 +456,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg(feature = "map")]
     fn test_kv_visitor() {
         let map1: BTreeMap<_, _> = [("x", 123), ("y", 234)].into_iter().collect();
         let map2: BTreeMap<_, _> = [("x", 321), ("y", 234), ("z", 345)].into_iter().collect();

--- a/src/serde_visit.rs
+++ b/src/serde_visit.rs
@@ -4,9 +4,9 @@ use std::{
     hash::Hash,
 };
 
-use super::{AtomicDiff, DeepDiff, Id, Replace};
 #[cfg(feature = "map")]
 use super::KvDiff;
+use super::{AtomicDiff, DeepDiff, Id, Replace};
 use crate::PatchOnlyDiff;
 
 /// A trait that allows the user to extract information from a 'diff' type.

--- a/src/serde_visit.rs
+++ b/src/serde_visit.rs
@@ -4,7 +4,9 @@ use std::{
     hash::Hash,
 };
 
-use super::{AtomicDiff, DeepDiff, Id, KvDiff, Replace};
+use super::{AtomicDiff, DeepDiff, Id, Replace};
+#[cfg(feature = "map")]
+use super::KvDiff;
 use crate::PatchOnlyDiff;
 
 /// A trait that allows the user to extract information from a 'diff' type.
@@ -160,6 +162,7 @@ tuple_impl!(A 0, B 1, C 2);
 tuple_impl!(A 0, B 1);
 tuple_impl!(A 0);
 
+#[cfg(feature = "map")]
 macro_rules! kv_map_impl {
     ($typ: ident, $bounds: ident) => {
         #[allow(
@@ -196,7 +199,9 @@ macro_rules! kv_map_impl {
     };
 }
 
+#[cfg(feature = "map")]
 kv_map_impl!(HashMap, Hash);
+#[cfg(feature = "map")]
 kv_map_impl!(BTreeMap, Ord);
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -78,6 +78,7 @@ struct SingleFieldC {
     reason = "We are specifically testing this behavior"
 )]
 mod just_check_they_compile {
+    #[cfg(feature = "map")]
     use std::collections::{BTreeMap, HashMap};
 
     use crate::{NotDiffable, SimpleStruct};
@@ -120,6 +121,7 @@ mod just_check_they_compile {
     }
 
     #[derive(difficient::Diffable, PartialEq, Debug, Clone)]
+    #[cfg(feature = "map")]
     struct HasHashMap {
         map1: HashMap<i32, i32>,
         map2: BTreeMap<i32, i32>,


### PR DESCRIPTION
The `map` feature, enabled by default, can be disable to remove map support, for codebases not supporting diffs over map to be expressed.

See https://github.com/redbadger/pathogen/pull/1 for some context on when map support might not be present.

Also in the current codebase, removing a value from a map, trigger an `unimplemented!` https://github.com/redbadger/difficient/blob/7d616b85c59cc4b718f72794967007510658a3ae/src/serde_visit.rs#L178